### PR TITLE
OKD/Openshift Deployment: SCC, Namespace, Service Account, GHCR, Workflow, Docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,9 @@ FROM nginx:alpine
 # Install curl for health checks
 RUN apk add --no-cache curl
 
-# Create nginx user if it doesn't exist (nginx user already exists in nginx:alpine)
-RUN id -u nginx >/dev/null 2>&1 || \
-    (addgroup -g 1001 -S nginx && \
-     adduser -S -D -H -u 1001 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx)
+# Create nginx group and user with the required UID for OKD SCC, only if not already present
+RUN id -u nginx >/dev/null 2>&1 || addgroup -g 1001 -S nginx
+RUN id -u nginx >/dev/null 2>&1 || adduser -S -D -H -u 1005220000 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx
 
 # Copy built application
 COPY --from=build /app/build /usr/share/nginx/html

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ set -e
 IMAGE_NAME="typesense-dashboard"
 IMAGE_TAG="latest"
 REGISTRY_URL="your-registry-url.com"  # Replace with your registry URL
-NAMESPACE="typesense-dashboard"
+NAMESPACE="wordpress-help"
 
 # Colors for output
 RED='\033[0;31m'

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: typesense-dashboard-config
-  namespace: typesense-dashboard
+  namespace: wordpress-help
   labels:
     app: typesense-dashboard
 data:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: typesense-dashboard
-  namespace: typesense-dashboard
+  namespace: wordpress-help
   labels:
     app: typesense-dashboard
 spec:
@@ -15,6 +15,7 @@ spec:
       labels:
         app: typesense-dashboard
     spec:
+      serviceAccountName: typesense-sa
       containers:
       - name: typesense-dashboard
         image: ghcr.io/amartya.g/typesense-dashboard:latest
@@ -51,7 +52,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 1001
+          runAsUser: 1005220000
           runAsGroup: 1001
           readOnlyRootFilesystem: true
           capabilities:

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -2,7 +2,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: typesense-dashboard-hpa
-  namespace: typesense-dashboard
+  namespace: wordpress-help
   labels:
     app: typesense-dashboard
 spec:

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: typesense-dashboard
+  name: wordpress-help
   labels:
-    name: typesense-dashboard
+    name: wordpress-help
     app: typesense-dashboard 

--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: typesense-dashboard-route
-  namespace: typesense-dashboard
+  namespace: wordpress-help
   labels:
     app: typesense-dashboard
   annotations:

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: typesense-dashboard-service
-  namespace: typesense-dashboard
+  namespace: wordpress-help
   labels:
     app: typesense-dashboard
 spec:


### PR DESCRIPTION
This PR adds full support for deploying the Typesense Dashboard to OKD/OpenShift with best practices for security and automation:
Key changes:
All Kubernetes manifests updated to use the wordpress-help namespace and typesense-sa service account (with SCC compatibility).
Deployment and Dockerfile updated to use a UID compatible with OpenShift SCCs.
Dockerfile and manifests now support running as a non-root user in OpenShift.
GitHub Actions workflow now builds and pushes Docker images to GitHub Container Registry (GHCR) on every release.
Deployment manifest pulls images from GHCR for reproducible, automated deployments.
Comprehensive documentation (DEPLOYMENT.md) for OKD/Openshift deployment, including SCC, service account, and troubleshooting.
Automated deployment script (deploy.sh) updated for new namespace and service account.
All files and instructions are ready for secure, production-grade OpenShift deployment.
How to use:
Merge this PR.
Create a GitHub release to trigger the workflow and publish the image to GHCR.
Apply the manifests in the wordpress-help namespace.